### PR TITLE
Fix the timing on showing the solutions

### DIFF
--- a/.vitepress/components/SolutionHider.vue
+++ b/.vitepress/components/SolutionHider.vue
@@ -2,7 +2,8 @@
     import { onMounted } from 'vue'
     import { useRoute } from 'vitepress'
 
-    const FIRST_LAB = new Date('2025-02-18T11:00:00+01:00').getTime();
+    // time when last lab in the first week ends
+    const SHOW_FIRST_SOLS = new Date('2025-02-20T18:00:00+01:00').getTime();
 
     const route = useRoute()
 
@@ -13,15 +14,15 @@
         for (const details of detailsElements) {
             const summary = details.querySelector('summary');
             const summaryContent = summary ? summary.outerHTML : '';
-            details.innerHTML = `${summaryContent} Solutions will be revealed at ${reveal_date}.`;
+            details.innerHTML = `${summaryContent} Solutions will be revealed after labs on ${reveal_date}.`;
         }
     }
     function handlePageChange() {
         const now = new Date(Date.now()).getTime();
         const page_week_no = parseInt(route.path.match(/\d+/)[0]) - 1;
         const millis_in_day = 24 * 60 * 60 * 1000;
-        const reveal_at = FIRST_LAB + (3 + 7 * page_week_no) * millis_in_day;
-        const days_left = Math.floor((reveal_at - now) / millis_in_day);
+        const reveal_at = SHOW_FIRST_SOLS + 7 * page_week_no * millis_in_day;
+        const days_left = (reveal_at - now) / millis_in_day;
         const should_reveal = days_left <= 0;
 
         if (!should_reveal) {


### PR DESCRIPTION
It was showing up at 11 on the day of the last labs - i.e., in time for the Czech labs. I'd prefer it after the labs since this leads to people copy-pasting code rather than trying to ask questions (in my experience).

I've edited it "in the browser" on the go; please check that I didn't mess anything up. 