### PR TITLE
Fixing `cheaper?`

### DIFF
--- a/exams/cheap-flights/index.md
+++ b/exams/cheap-flights/index.md
@@ -78,7 +78,7 @@ partial solutions to extend the cheapest path.
 In Scheme you can `sort` a list with the help of a predicate function taking two arguments. In case
 of a list of lists (containing cost and path) you could do the following:
 ```racket
-> (define (cheaper? x y) (< (car x) (car y)))
+> (define (cheaper? x y) (< (cadr x) (cadr y)))
 > (sort '(((2 3) 2.0) ((2 1 3) 1.5)) cheaper?)
 '(((2 1 3) 1.5) ((2 3) 2.0))
 ```


### PR DESCRIPTION
Function cheaper? is wrongly defined for current input. It compares (2 3) with (2 1 3) instead of 2.0 with 1.5.